### PR TITLE
♻️ refactor : CSR API 요청 SSR로 변경

### DIFF
--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -30,6 +30,7 @@ const getSearchList = async (pageNo = 1, keyword = "화성") => {
   const unFilteredData = await axios.get(
     `/api/searchList?${essentialParams}&pageNo=${pageNo}&keyword=${keyword}`
   );
+
   const filteredData = filtering(unFilteredData);
   return filteredData !== undefined ? filteredData : [];
 };
@@ -42,4 +43,29 @@ const getImageList = async (pageNo = 1, contentId = 3429) => {
   return filteredData;
 };
 
-export { getBasedList, getLocationBasedList, getSearchList, getImageList };
+const getServerSideSearchList = async (pageNo = 1, keyword = "화성") => {
+  const unFilteredData = await axios.get(
+    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/searchList?${essentialParams}&pageNo=${pageNo}&keyword=${encodeURI(
+      keyword
+    )}`
+  );
+  const filteredData = filtering(unFilteredData);
+  return filteredData !== undefined ? filteredData : [];
+};
+
+const getServerSideImageList = async (pageNo = 1, contentId = 3429) => {
+  const unFilteredData = await axios.get(
+    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/imageList?${essentialParams}&pageNo=${pageNo}&contentId=${contentId}`
+  );
+  const filteredData = filteringUrl(unFilteredData) || [];
+  return filteredData;
+};
+
+export {
+  getBasedList,
+  getLocationBasedList,
+  getSearchList,
+  getImageList,
+  getServerSideSearchList,
+  getServerSideImageList,
+};

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -1,33 +1,28 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/dist/client/router";
-import { getSearchList, getImageList } from "@/core/api/axios";
+import {
+  getServerSideImageList,
+  getServerSideSearchList,
+} from "@/core/api/axios";
 import styled from "styled-components";
 import Slider from "@/components/Slider";
 import Intro from "@/components/Intro";
 import KakaoAPI from "@/components/KakaoAPI";
 import Footer from "@/components/Semantic/Footer";
 import Header from "@/components/Semantic/Header";
+import axios from "axios";
 
-const Content = () => {
-  const router = useRouter();
+const Content = ({
+  content: serverSierContent,
+  imageLists: serverSideImageLists,
+}) => {
   const [content, setContent] = useState([]);
   const [imageLists, setImageLists] = useState([]);
 
   useEffect(() => {
-    if (!router.isReady) return;
-    searchList(1, router.query.keyword);
-    imageList(1, router.query.id);
-  }, [router.isReady]);
-
-  async function searchList(pageNo = 1, keyword) {
-    const data = await getSearchList(pageNo, keyword);
-    setContent(data[0]);
-  }
-
-  async function imageList(pageNo = 1, contentId) {
-    const data = await getImageList(pageNo, contentId);
-    setImageLists(data);
-  }
+    setContent(serverSierContent);
+    setImageLists(serverSideImageLists);
+  }, []);
 
   return (
     <>
@@ -51,6 +46,24 @@ const Content = () => {
   );
 };
 
+// 여기 데이터로 먼저 API 호출 진행
+export async function getServerSideProps({ query }) {
+  let content, imageLists;
+  async function searchList(pageNo = 1, keyword) {
+    const data = await getServerSideSearchList(pageNo, keyword);
+    content = data[0];
+  }
+
+  async function imageList(pageNo = 1, contentId) {
+    const data = await getServerSideImageList(pageNo, contentId);
+    imageLists = data;
+  }
+  await searchList(1, query.keyword);
+  await imageList(1, query.id);
+
+  return { props: { content, imageLists } };
+}
+
 const Body = styled.div`
   width: 100%;
   min-height: 100vh;
@@ -62,12 +75,12 @@ const Main = styled.div`
   height: auto;
   align-items: center;
 
-  @media (max-width: 600px) {
+  @media (max-width: 900px) {
     min-width: 300px;
     margin: 0vw 5vw;
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: 900px) {
     width: calc(100vw - 22vw * 2);
     margin: 0vw 22vw;
   }


### PR DESCRIPTION
# 기존 API 요청 (CSR)
```js
useEffect(() => {
    if (!router.isReady) return;
    searchList(1, router.query.keyword);
    imageList(1, router.query.id);
  }, [router.isReady]);

  async function searchList(pageNo = 1, keyword) {
    const data = await getSearchList(pageNo, keyword);
    setContent(data[0]);
  }

  async function imageList(pageNo = 1, contentId) {
    const data = await getImageList(pageNo, contentId);
    setImageLists(data);
  }
```

# 수정한 API 요청 (SSR)
```js
export async function getServerSideProps({ query }) {
  let content, imageLists;
  async function searchList(pageNo = 1, keyword) {
    const data = await getServerSideSearchList(pageNo, keyword);
    content = data[0];
  }

  async function imageList(pageNo = 1, contentId) {
    const data = await getServerSideImageList(pageNo, contentId);
    imageLists = data;
  }
  await searchList(1, query.keyword);
  await imageList(1, query.id);

  return { props: { content, imageLists } };
}
```

# 주의할 점 
## Request path contains unescaped characters
> SSR로 변경하면서 API를 사용할 때 발생한 에러이다. 
요청 경로에 처리하지 못하는 문자가 있는 것
현재 나의 API는 한글이나 띄어쓰기가 존재한다. 
이러한 부분을 처리하기 위해 `encodeURI` 메소드를 이용하여 해당 부분을 묶어주면 해결이 된다. 

* 대신 주의할 점으로 다른 부분도 묶었다가 serviceKey 부분에서 
`resultMsg: 'SERVICE_KEY_IS_NOT_REGISTERED_ERROR'` 라는 에러를 얻게 될 수 있어 주의하여야 한다. 

## serviceKey를 `encodeURI`로 묶었을 때 에러 
```js
{
  responseTime: '2022-10-17T23:22:10.643',
  resultCode: '30',
  resultMsg: 'SERVICE_KEY_IS_NOT_REGISTERED_ERROR'
}
```