### PR TITLE
♻️ refactor : useCallback + memo 처리 

### DIFF
--- a/components/Semantic/Header/Header.jsx
+++ b/components/Semantic/Header/Header.jsx
@@ -21,11 +21,11 @@ const Header = ({
       </ImgContainer>
       {isInputExist && (
         <Input
-          searchArr={searchArr}
+          // searchArr={searchArr}
+          // isSearching={isSearching}
           changeInputValue={changeInputValue}
           checkSearchPressEnter={checkSearchPressEnter}
           clearSearchArr={clearSearchArr}
-          isSearching={isSearching}
         ></Input>
       )}
       <HamburgerContainer>

--- a/components/Semantic/Header/Header.jsx
+++ b/components/Semantic/Header/Header.jsx
@@ -21,8 +21,8 @@ const Header = ({
       </ImgContainer>
       {isInputExist && (
         <Input
-          // searchArr={searchArr}
-          // isSearching={isSearching}
+          searchArr={searchArr}
+          isSearching={isSearching}
           changeInputValue={changeInputValue}
           checkSearchPressEnter={checkSearchPressEnter}
           clearSearchArr={clearSearchArr}

--- a/components/Semantic/Header/Input.jsx
+++ b/components/Semantic/Header/Input.jsx
@@ -27,7 +27,6 @@ const Input = memo(
         changeInputValue(e);
       }, 500);
     };
-    console.log("!!!");
     function keyUp(e) {
       if (searchArr.length !== 0) {
         if (e.key === "ArrowDown") {

--- a/components/Semantic/Header/Input.jsx
+++ b/components/Semantic/Header/Input.jsx
@@ -1,123 +1,125 @@
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, memo } from "react";
 import { useRouter } from "next/router";
 import styled from "styled-components";
 import { ImSearch } from "react-icons/im";
 
-const Input = ({
-  searchArr = [],
-  isSearching,
-  changeInputValue,
-  checkSearchPressEnter,
-  clearSearchArr,
-  width = 20,
-  height = 50,
-  borderRadius = 20,
-  placeholder,
-}) => {
-  let timer;
-  const router = useRouter();
-  const inputRef = useRef();
-  const [idx, setIdx] = useState(-1);
-  const debounce = (e) => {
-    if (timer) {
-      clearTimeout(timer); // 0.5초 미만으로 입력이 주어질 경우 해당 timer를 clear(없앤다)한다.
-    }
-    timer = setTimeout(() => {
-      changeInputValue(e);
-    }, 500);
-  };
-
-  function keyUp(e) {
-    if (searchArr.length !== 0) {
-      if (e.key === "ArrowDown") {
-        const nIdx = (idx + 1) % searchArr.length;
-        setIdx(nIdx);
-      } else if (e.key === "ArrowUp") {
-        const nIdx = (idx - 1) % searchArr.length;
-        setIdx(nIdx < 0 ? nIdx + searchArr.length : nIdx);
-      } else if (e.key === "Enter") {
-        if (idx === -1) {
-          checkSearchPressEnter(e, idx);
-        } else {
-          checkSearchPressEnter(
-            e,
-            idx,
-            searchArr[idx].facltNm,
-            searchArr[idx].contentId
-          );
+const Input = memo(
+  ({
+    searchArr = [],
+    isSearching,
+    changeInputValue,
+    checkSearchPressEnter,
+    clearSearchArr,
+    width = 20,
+    height = 50,
+    borderRadius = 20,
+    placeholder,
+  }) => {
+    let timer;
+    const router = useRouter();
+    const inputRef = useRef();
+    const [idx, setIdx] = useState(-1);
+    const debounce = (e) => {
+      if (timer) {
+        clearTimeout(timer); // 0.5초 미만으로 입력이 주어질 경우 해당 timer를 clear(없앤다)한다.
+      }
+      timer = setTimeout(() => {
+        changeInputValue(e);
+      }, 500);
+    };
+    console.log("!!!");
+    function keyUp(e) {
+      if (searchArr.length !== 0) {
+        if (e.key === "ArrowDown") {
+          const nIdx = (idx + 1) % searchArr.length;
+          setIdx(nIdx);
+        } else if (e.key === "ArrowUp") {
+          const nIdx = (idx - 1) % searchArr.length;
+          setIdx(nIdx < 0 ? nIdx + searchArr.length : nIdx);
+        } else if (e.key === "Enter") {
+          if (idx === -1) {
+            checkSearchPressEnter(e, idx);
+          } else {
+            checkSearchPressEnter(
+              e,
+              idx,
+              searchArr[idx].facltNm,
+              searchArr[idx].contentId
+            );
+          }
         }
       }
     }
+
+    const clickSearch = ({ contentId, facltNm }) => {
+      router.push(`/content/${contentId}?keyword=${facltNm}`);
+    };
+
+    useEffect(() => {
+      setIdx(-1);
+    }, [searchArr]);
+
+    return (
+      <InputContainer
+        width={width}
+        height={height}
+        borderRadius={borderRadius}
+        searchArr={searchArr}
+        isSearching={isSearching}
+      >
+        <InputTagContainer>
+          <ImSearch />
+          <InputTag
+            ref={inputRef}
+            onChange={debounce}
+            onBlur={clearSearchArr}
+            width={width}
+            height={height}
+            borderRadius={borderRadius}
+            searchArr={searchArr}
+            onKeyUp={keyUp}
+          ></InputTag>
+        </InputTagContainer>
+        {isSearching &&
+          (searchArr.length !== 0 ? (
+            <Ul width={width} height={height} borderRadius={borderRadius}>
+              {searchArr.map(({ facltNm, contentId }, liIdx) => {
+                return (
+                  <Li
+                    key={contentId}
+                    onMouseDown={() => clickSearch({ contentId, facltNm })}
+                    width={width}
+                    height={height}
+                    isFocus={idx == liIdx}
+                  >
+                    {facltNm}
+                  </Li>
+                );
+              })}
+              <Li
+                id="backgroundWhite"
+                width={width}
+                height={5}
+                borderRadius={borderRadius}
+              ></Li>
+            </Ul>
+          ) : (
+            <Ul width={width} height={height} borderRadius={borderRadius}>
+              <Li id="backgroundWhite" width={width} height={height}>
+                검색결과 없음
+              </Li>
+              <Li
+                id="backgroundWhite"
+                width={width}
+                height={5}
+                borderRadius={borderRadius}
+              ></Li>
+            </Ul>
+          ))}
+      </InputContainer>
+    );
   }
-
-  const clickSearch = ({ contentId, facltNm }) => {
-    router.push(`/content/${contentId}?keyword=${facltNm}`);
-  };
-
-  useEffect(() => {
-    setIdx(-1);
-  }, [searchArr]);
-
-  return (
-    <InputContainer
-      width={width}
-      height={height}
-      borderRadius={borderRadius}
-      searchArr={searchArr}
-      isSearching={isSearching}
-    >
-      <InputTagContainer>
-        <ImSearch />
-        <InputTag
-          ref={inputRef}
-          onChange={debounce}
-          onBlur={clearSearchArr}
-          width={width}
-          height={height}
-          borderRadius={borderRadius}
-          searchArr={searchArr}
-          onKeyUp={keyUp}
-        ></InputTag>
-      </InputTagContainer>
-      {isSearching &&
-        (searchArr.length !== 0 ? (
-          <Ul width={width} height={height} borderRadius={borderRadius}>
-            {searchArr.map(({ facltNm, contentId }, liIdx) => {
-              return (
-                <Li
-                  key={contentId}
-                  onMouseDown={() => clickSearch({ contentId, facltNm })}
-                  width={width}
-                  height={height}
-                  isFocus={idx == liIdx}
-                >
-                  {facltNm}
-                </Li>
-              );
-            })}
-            <Li
-              id="backgroundWhite"
-              width={width}
-              height={5}
-              borderRadius={borderRadius}
-            ></Li>
-          </Ul>
-        ) : (
-          <Ul width={width} height={height} borderRadius={borderRadius}>
-            <Li id="backgroundWhite" width={width} height={height}>
-              검색결과 없음
-            </Li>
-            <Li
-              id="backgroundWhite"
-              width={width}
-              height={5}
-              borderRadius={borderRadius}
-            ></Li>
-          </Ul>
-        ))}
-    </InputContainer>
-  );
-};
+);
 
 const InputContainer = styled.div`
   box-sizing: border-box;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   getBasedList,
   getLocationBasedList,
@@ -46,6 +46,44 @@ export default function Home() {
     }
   }, [gpsData]);
 
+  // Header 검색 기능
+  const changeSearchValue = useCallback(async ({ target }) => {
+    if (target.value !== "") {
+      const list = await getSearchList(1, target.value);
+      const filterList = list.map(({ facltNm, contentId, mapX, mapY }) => ({
+        facltNm,
+        contentId,
+        mapX,
+        mapY,
+      }));
+
+      setIsSearching(true);
+      setSearchArr(filterList);
+    } else {
+      setIsSearching(false);
+      setSearchArr([]);
+    }
+  }, []);
+
+  const checkSearchPressEnter = useCallback(
+    ({ target, key }, idx, facltNm, contentId) => {
+      if (idx === -1) {
+        searchList(1, target.value);
+        setSearchArr([]);
+        setIsSearching(false);
+      } else {
+        router.push(`/content/${contentId}?keyword=${facltNm}`);
+      }
+    },
+    []
+  );
+
+  const clearSearchArr = useCallback(() => {
+    setSearchArr([]);
+    setIsSearching(false);
+  }, []);
+
+  // API 기능 : basedList
   async function basedList(pageNo = 1) {
     const data = await getBasedList(pageNo);
     setTitleTag("nogps");
@@ -55,6 +93,7 @@ export default function Home() {
     } else if (data !== undefined) setCampData([...campData, ...data]);
   }
 
+  // API 기능 : locationBasedList
   async function locationBasedList(pageNo = 1) {
     const gpsInfo = {
       mapX: gpsData.long,
@@ -72,6 +111,7 @@ export default function Home() {
     } else setCampData([...campData, ...data]);
   }
 
+  // API 기능 : searchList
   async function searchList(pageNo, value) {
     const list = await getSearchList(pageNo, value);
     setTitleTag("searchKey");
@@ -86,35 +126,6 @@ export default function Home() {
       alert("더보기 캠핑 목록이 없습니다.");
     } else setCampData([...campData, ...list]);
   }
-
-  // Header 검색 기능
-  const changeSearchValue = async ({ target }) => {
-    if (target.value !== "") {
-      const list = await getSearchList(1, target.value);
-      const filterList = list.map(({ facltNm, contentId, mapX, mapY }) => ({
-        facltNm,
-        contentId,
-        mapX,
-        mapY,
-      }));
-
-      setIsSearching(true);
-      setSearchArr(filterList);
-    } else {
-      setIsSearching(false);
-      setSearchArr([]);
-    }
-  };
-
-  const checkSearchPressEnter = ({ target, key }, idx, facltNm, contentId) => {
-    if (idx === -1) {
-      searchList(1, target.value);
-      setSearchArr([]);
-      setIsSearching(false);
-    } else {
-      router.push(`/content/${contentId}?keyword=${facltNm}`);
-    }
-  };
 
   // 더보기 기능
   const clickBtn = () => {
@@ -144,10 +155,6 @@ export default function Home() {
     locationBasedList(pageNo.current);
   };
 
-  const clearSearchArr = () => {
-    setSearchArr([]);
-    setIsSearching(false);
-  };
   return (
     <>
       <Header


### PR DESCRIPTION
# 기존 코드 
> 부모 pages/index.js의 파일에서 리렌더링이 발생할 경우 하위 컴포넌트들도 리렌더링이 발생한다. 
하지만, 관련이 없는 props의 변화로 인한 관련이 없는 컴포넌트까지 리렌더링을 할 필요는 없다. 

## 현재 상황
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/59253551/198864410-68a886f9-960a-4989-b64a-a03eeaa33118.png">

## 범위 설정을 했을 때 
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/59253551/198864413-a76a23f3-3b64-4ffb-94a2-2328401c1a20.png">

범위 설정은 Header의 Input 컴포넌트와는 연관이 없다. 
하지만, Input 컴포넌트가 리렌더링이 진행된다. => 이는 불필요한 리렌더링이 확실하고 이는 성능 개선에 좋지 못하다. 

# 개선 코드 작성하기
## 전달 props 생각하기
```js
<Header
        isInputExist={true}
        searchArr={searchArr}
        isSearching={isSearching}
        changeInputValue={changeSearchValue}
        checkSearchPressEnter={checkSearchPressEnter}
        clearSearchArr={clearSearchArr}
      />
```
>전달하는 내용 중 상태값과 함수는 총 5개이다. 
searchArr, isSearching은 상태값이고 changeInputValue, checkSearchPressEnter, clearSearchArr는 함수이다. 

## memo를 사용하기
### React 공식 설명
컴포넌트가 동일한 props로 동일한 결과를 렌더링해낸다면, React.memo를 호출하고 결과를 메모이징(Memoizing)하도록 래핑하여 경우에 따라 성능 향상을 누릴 수 있습니다. 즉, React는 컴포넌트를 렌더링하지 않고 마지막으로 렌더링된 결과를 재사용

### 나의 이해한 설명
기존에는 부모가 리렌더링 되면 자식도 리렌더링 된다. 
하지만, memo를 이용하면 부모가 리렌더링 되어도 자식의 받은 props가 변하지 않는한 리렌더링이 되지않는다. 

## memo 적용 및 결과
여전히 Input 컴포넌트는 리렌더링이 되었다. 
즉, props가 변한다는 것이다. 

## useCallback 사용하기
- 함수의 경우 리렌더링을 할 경우 함수의 재정의에 의해 새로운 메모리에 할당된 함수와 기존에 정의된 함수간의 서로 다르게 인식을 한다.
- 해당 함수를 자식 컴포넌트의 prop으로 전달할 경우 prop의 변경으로 리렌더링이 된다. 
⇒ 이를 useCallback으로 막을 수 있다.

즉, 부모에서 사용하는 함수중에 Input 컴포넌트 props로 전달되는 부분들을 useCallback을 사용한다. 

ex)
```js
 const clearSearchArr = useCallback(() => {
    setSearchArr([]);
    setIsSearching(false);
  }, []);
```
뒤에 2번째 매개변수는 배열로 해야 정상적으로 동작한다. 

## useCallback 적용 및 결과 ( +memo )
### 초기화면
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/59253551/198864831-dfa4cbe4-a2c7-4ac0-ab97-a045e2f5a4c9.png">

### 범위 설정을 했을 때 
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/59253551/198864832-c280dd9a-a686-4a05-a703-85121a799c49.png">

### 더보기 버튼을 눌렀을 때 
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/59253551/198864833-2686644e-0a0e-482d-9151-12582b352b82.png">

> 리렌더링 시에 Input 컴포넌트가 리렌더링 되는 것을 막을 수 있었다. 

