### PR TITLE
♻️ refactor : API Routes Response 사용

### DIFF
--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -47,7 +47,6 @@ const getServerSideSearchList = async (pageNo = 1, keyword = "화성") => {
       process.env.SERVICE_TYPE
     }&pageNo=${pageNo}&keyword=${encodeURI(keyword)}`
   );
-  console.log(unFilteredData);
   const filteredData = filtering(unFilteredData);
   return filteredData !== undefined ? filteredData : [];
 };

--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -8,9 +8,7 @@ const filteringUrl = (target) =>
   target?.data?.response?.body?.items?.item?.map(({ imageUrl }) => imageUrl);
 
 const getBasedList = async (pageNo = 1) => {
-  const unFilteredData = await axios.get(
-    `/api/basedList?&pageNo=${pageNo}`
-  );
+  const unFilteredData = await axios.get(`/api/basedList?&pageNo=${pageNo}`);
   const filteredData = filtering(unFilteredData);
   return filteredData;
 };
@@ -28,7 +26,7 @@ const getLocationBasedList = async (
 
 const getSearchList = async (pageNo = 1, keyword = "화성") => {
   const unFilteredData = await axios.get(
-    `/api/searchList?${essentialParams}&pageNo=${pageNo}&keyword=${keyword}`
+    `/api/searchList?&pageNo=${pageNo}&keyword=${encodeURI(keyword)}`
   );
 
   const filteredData = filtering(unFilteredData);
@@ -37,7 +35,7 @@ const getSearchList = async (pageNo = 1, keyword = "화성") => {
 
 const getImageList = async (pageNo = 1, contentId = 3429) => {
   const unFilteredData = await axios.get(
-    `/api/imageList?${essentialParams}&pageNo=${pageNo}&contentId=${contentId}`
+    `/api/imageList?&pageNo=${pageNo}&contentId=${contentId}`
   );
   const filteredData = filteringUrl(unFilteredData) || [];
   return filteredData;
@@ -45,17 +43,18 @@ const getImageList = async (pageNo = 1, contentId = 3429) => {
 
 const getServerSideSearchList = async (pageNo = 1, keyword = "화성") => {
   const unFilteredData = await axios.get(
-    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/searchList?${essentialParams}&pageNo=${pageNo}&keyword=${encodeURI(
-      keyword
-    )}`
+    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/searchList?${essentialParams}&${
+      process.env.SERVICE_TYPE
+    }&pageNo=${pageNo}&keyword=${encodeURI(keyword)}`
   );
+  console.log(unFilteredData);
   const filteredData = filtering(unFilteredData);
   return filteredData !== undefined ? filteredData : [];
 };
 
 const getServerSideImageList = async (pageNo = 1, contentId = 3429) => {
   const unFilteredData = await axios.get(
-    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/imageList?${essentialParams}&pageNo=${pageNo}&contentId=${contentId}`
+    `http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/imageList?${essentialParams}&${process.env.SERVICE_TYPE}&pageNo=${pageNo}&contentId=${contentId}`
   );
   const filteredData = filteringUrl(unFilteredData) || [];
   return filteredData;

--- a/core/api/axios.js
+++ b/core/api/axios.js
@@ -9,7 +9,7 @@ const filteringUrl = (target) =>
 
 const getBasedList = async (pageNo = 1) => {
   const unFilteredData = await axios.get(
-    `/api/basedList?${essentialParams}&pageNo=${pageNo}`
+    `/api/basedList?&pageNo=${pageNo}`
   );
   const filteredData = filtering(unFilteredData);
   return filteredData;
@@ -20,7 +20,7 @@ const getLocationBasedList = async (
   { mapX = 127, mapY = 37, radius = 1000 }
 ) => {
   const unFilteredData = await axios.get(
-    `/api/locationBasedList?${essentialParams}&pageNo=${pageNo}&mapX=${mapX}&mapY=${mapY}&radius=${radius}`
+    `/api/locationBasedList?&pageNo=${pageNo}&mapX=${mapX}&mapY=${mapY}&radius=${radius}`
   );
   const filteredData = filtering(unFilteredData);
   return filteredData !== undefined ? filteredData : [];

--- a/core/utils/mainPage.js
+++ b/core/utils/mainPage.js
@@ -7,7 +7,7 @@ const returnTitle = (titleTag, searchKey = "") => {
   return "🏕️ " + titleCase[titleTag];
 };
 
-function getLocation(setData) {
+function getLocation(setData, gpsCheck) {
   if (navigator.geolocation) {
     // GPS를 지원하면
     navigator.geolocation.getCurrentPosition(
@@ -16,8 +16,10 @@ function getLocation(setData) {
           lati: position.coords.latitude,
           long: position.coords.longitude,
         });
+        gpsCheck.current = true;
       },
       function (error) {
+        gpsCheck.current = true;
         console.error(error);
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -4,14 +4,14 @@ const nextConfig = {
   env: {
     SERVICE_KEY: process.env.SERVICE_KEY,
   },
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `http://apis.data.go.kr/B551011/GoCamping/:path*`,
-      },
-    ];
-  },
+  // async rewrites() {
+  //   return [
+  //     {
+  //       source: "/api/:path*",
+  //       destination: `http://apis.data.go.kr/B551011/GoCamping/:path*`,
+  //     },
+  //   ];
+  // },
   images: {
     domains: ["gocamping.or.kr"],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,7 @@ const nextConfig = {
   images: {
     domains: ["gocamping.or.kr"],
   },
+  reactStrictMode: false,
 };
 
 module.exports = nextConfig;

--- a/pages/api/basedList.js
+++ b/pages/api/basedList.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import getURL from "./url.js";
 let result;
 export default async function handler(req, res) {
   const { query } = req;
@@ -6,9 +7,7 @@ export default async function handler(req, res) {
     .map(([key, value]) => `&${key}=${value}`)
     .join("");
   try {
-    result = await axios.get(
-      `http://apis.data.go.kr/B551011/GoCamping/basedList?MobileOS=WIN&MobileApp=AppTest&_type=json&serviceKey=u%2BXsTVV1nl13bsl5mxFNCaZ0o48loSbVj4pQoNm2xFONwLswAgYcNrabZ9jBp7mIdKQZSgYV7NBAjOyHH6cr%2Fg%3D%3D${queryStr}`
-    );
+    result = await axios.get(`${getURL('basedList')}${queryStr}`);
     res.status(200).json(result.data);
   } catch (err) {
     res.status(500).json({ error: "failed to load data" });

--- a/pages/api/basedList.js
+++ b/pages/api/basedList.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+let result;
+export default async function handler(req, res) {
+  const { query } = req;
+  const queryStr = Object.entries(query)
+    .map(([key, value]) => `&${key}=${value}`)
+    .join("");
+  try {
+    result = await axios.get(
+      `http://apis.data.go.kr/B551011/GoCamping/basedList?MobileOS=WIN&MobileApp=AppTest&_type=json&serviceKey=u%2BXsTVV1nl13bsl5mxFNCaZ0o48loSbVj4pQoNm2xFONwLswAgYcNrabZ9jBp7mIdKQZSgYV7NBAjOyHH6cr%2Fg%3D%3D${queryStr}`
+    );
+    res.status(200).json(result.data);
+  } catch (err) {
+    res.status(500).json({ error: "failed to load data" });
+  }
+}

--- a/pages/api/basedList.js
+++ b/pages/api/basedList.js
@@ -7,7 +7,7 @@ export default async function handler(req, res) {
     .map(([key, value]) => `&${key}=${value}`)
     .join("");
   try {
-    result = await axios.get(`${getURL('basedList')}${queryStr}`);
+    result = await axios.get(`${getURL("basedList")}${queryStr}`);
     res.status(200).json(result.data);
   } catch (err) {
     res.status(500).json({ error: "failed to load data" });

--- a/pages/api/imageList.js
+++ b/pages/api/imageList.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+import getURL from "./url.js";
+let result;
+export default async function handler(req, res) {
+  const { query } = req;
+  const queryStr = Object.entries(query)
+    .map(([key, value]) => `&${key}=${value}`)
+    .join("");
+  try {
+    result = await axios.get(`${getURL("imageList")}${queryStr}`);
+    res.status(200).json(result.data);
+  } catch (err) {
+    res.status(500).json({ error: "failed to load data" });
+  }
+}

--- a/pages/api/locationBasedList.js
+++ b/pages/api/locationBasedList.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+let result;
+export default async function handler(req, res) {
+  const { query } = req;
+  const queryStr = Object.entries(query)
+    .map(([key, value]) => `&${key}=${value}`)
+    .join("");
+  try {
+    result = await axios.get(
+      `http://apis.data.go.kr/B551011/GoCamping/locationBasedList?MobileOS=WIN&MobileApp=AppTest&_type=json&serviceKey=u%2BXsTVV1nl13bsl5mxFNCaZ0o48loSbVj4pQoNm2xFONwLswAgYcNrabZ9jBp7mIdKQZSgYV7NBAjOyHH6cr%2Fg%3D%3D${queryStr}`
+    );
+    res.status(200).json(result.data);
+  } catch (err) {
+    res.status(500).json({ error: "failed to load data" });
+  }
+}

--- a/pages/api/locationBasedList.js
+++ b/pages/api/locationBasedList.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import getURL from "./url.js";
 let result;
 export default async function handler(req, res) {
   const { query } = req;
@@ -6,9 +7,7 @@ export default async function handler(req, res) {
     .map(([key, value]) => `&${key}=${value}`)
     .join("");
   try {
-    result = await axios.get(
-      `http://apis.data.go.kr/B551011/GoCamping/locationBasedList?MobileOS=WIN&MobileApp=AppTest&_type=json&serviceKey=u%2BXsTVV1nl13bsl5mxFNCaZ0o48loSbVj4pQoNm2xFONwLswAgYcNrabZ9jBp7mIdKQZSgYV7NBAjOyHH6cr%2Fg%3D%3D${queryStr}`
-    );
+    result = await axios.get(`${getURL("locationBasedList")}${queryStr}`);
     res.status(200).json(result.data);
   } catch (err) {
     res.status(500).json({ error: "failed to load data" });

--- a/pages/api/searchList.js
+++ b/pages/api/searchList.js
@@ -6,10 +6,8 @@ export default async function handler(req, res) {
   const queryStr = Object.entries(query)
     .map(([key, value]) => `&${key}=${value}`)
     .join("");
-  console.log(`${getURL("searchList")}${queryStr}`);
   try {
     result = await axios.get(`${getURL("searchList")}${queryStr}`);
-    console.log(result.data);
     res.status(200).json(result.data);
   } catch (err) {
     res.status(500).json({ error: "failed to load data" });

--- a/pages/api/searchList.js
+++ b/pages/api/searchList.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+import getURL from "./url.js";
+let result;
+export default async function handler(req, res) {
+  const { query } = req;
+  const queryStr = Object.entries(query)
+    .map(([key, value]) => `&${key}=${value}`)
+    .join("");
+  console.log(`${getURL("searchList")}${queryStr}`);
+  try {
+    result = await axios.get(`${getURL("searchList")}${queryStr}`);
+    console.log(result.data);
+    res.status(200).json(result.data);
+  } catch (err) {
+    res.status(500).json({ error: "failed to load data" });
+  }
+}

--- a/pages/api/url.js
+++ b/pages/api/url.js
@@ -1,0 +1,4 @@
+const url = `http://apis.data.go.kr/B551011/GoCamping`;
+export default function getURL(props) {
+  return `${url}/${props}?${process.env.SERVICE_KEY}&${process.env.SERVICE_TYPE}`;
+}

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -1,35 +1,30 @@
-import { useState, useEffect } from "react";
 import {
   getServerSideSearchList,
   getServerSideImageList,
 } from "@/core/api/axios";
 import styled from "styled-components";
-
 import { Header, Footer, Slider, Intro, KakaoAPI } from "@/components/index.js";
-import { useRouter } from "next/router";
 
 const Content = ({ serverImage, serverContent }) => {
-  const [content, setContent] = useState([]);
-  const [imageLists, setImageLists] = useState([]);
-  useEffect(() => {
-    setContent(serverContent);
-    setImageLists(serverImage);
-  }, []);
   return (
     <>
       <Header />
       <Body id="backgroundLightGray">
         <Main>
-          <Title id="titleText">🏕️ {content?.facltNm}</Title>
-          {imageLists.length !== 0 && <Slider imgs={imageLists} width={40} />}
+          <Title id="titleText">🏕️ {serverContent?.facltNm}</Title>
+          {serverImage.length !== 0 && <Slider imgs={serverImage} width={40} />}
           <IntroContainer>
-            <Intro introText={content?.intro} />
+            <Intro introText={serverContent?.intro} />
           </IntroContainer>
           <Location>
             <div id="titleText">위치</div>
-            <div id="subText">{content?.addr1}</div>
+            <div id="subText">{serverContent?.addr1}</div>
           </Location>
-          <KakaoAPI long={content?.mapX} lati={content?.mapY} marginH={10} />
+          <KakaoAPI
+            long={serverContent?.mapX}
+            lati={serverContent?.mapY}
+            marginH={10}
+          />
         </Main>
       </Body>
       <Footer />

--- a/pages/content/[id].js
+++ b/pages/content/[id].js
@@ -1,24 +1,20 @@
 import { useState, useEffect } from "react";
 import {
-  getServerSideImageList,
   getServerSideSearchList,
+  getServerSideImageList,
 } from "@/core/api/axios";
 import styled from "styled-components";
 
 import { Header, Footer, Slider, Intro, KakaoAPI } from "@/components/index.js";
+import { useRouter } from "next/router";
 
-const Content = ({
-  content: serverSierContent,
-  imageLists: serverSideImageLists,
-}) => {
+const Content = ({ serverImage, serverContent }) => {
   const [content, setContent] = useState([]);
   const [imageLists, setImageLists] = useState([]);
-
   useEffect(() => {
-    setContent(serverSierContent);
-    setImageLists(serverSideImageLists);
+    setContent(serverContent);
+    setImageLists(serverImage);
   }, []);
-
   return (
     <>
       <Header />
@@ -41,22 +37,13 @@ const Content = ({
   );
 };
 
-// 여기 데이터로 먼저 API 호출 진행
-export async function getServerSideProps({ query }) {
-  let content, imageLists;
-  async function searchList(pageNo = 1, keyword) {
-    const data = await getServerSideSearchList(pageNo, keyword);
-    content = data[0];
-  }
-
-  async function imageList(pageNo = 1, contentId) {
-    const data = await getServerSideImageList(pageNo, contentId);
-    imageLists = data;
-  }
-  await searchList(1, query.keyword);
-  await imageList(1, query.id);
-
-  return { props: { content, imageLists } };
+export async function getServerSideProps(context) {
+  const { id, keyword } = context.query;
+  const image = await getServerSideImageList(1, id);
+  const content = await getServerSideSearchList(1, keyword);
+  return {
+    props: { serverContent: content[0], serverImage: image },
+  };
 }
 
 const Body = styled.div`

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,6 +23,7 @@ export default function Home() {
   const pageNo = useRef(1);
   const [gpsData, setGpsData] = useState({});
   const gpsRange = useRef(10000);
+  const gpsCheck = useRef(false);
 
   const [searchArr, setSearchArr] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -32,17 +33,14 @@ export default function Home() {
   const router = useRouter();
 
   useEffect(() => {
-    getLocation(setGpsData);
+    getLocation(setGpsData, gpsCheck);
   }, []);
-
   useEffect(() => {
     // GPS Data 여부에 따라 API 분기 실행
-    if (Object.keys(gpsData).length !== 0) {
-      console.log("GPS 실행");
-      locationBasedList();
-    } else {
-      console.log("GPS 실행X");
+    if (Object.keys(gpsData).length === 0 && gpsCheck.current) {
       basedList();
+    } else if (Object.keys(gpsData).length !== 0 && gpsCheck.current) {
+      locationBasedList();
     }
   }, [gpsData]);
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,6 @@ export default function Home() {
   const [titleTag, setTitleTag] = useState("nogps");
   const [campData, setCampData] = useState([]);
   const pageNo = useRef(1);
-
   const [gpsData, setGpsData] = useState({});
   const gpsRange = useRef(10000);
 
@@ -39,8 +38,10 @@ export default function Home() {
   useEffect(() => {
     // GPS Data 여부에 따라 API 분기 실행
     if (Object.keys(gpsData).length !== 0) {
+      console.log("GPS 실행");
       locationBasedList();
     } else {
+      console.log("GPS 실행X");
       basedList();
     }
   }, [gpsData]);


### PR DESCRIPTION
# 🟥 기존 rewrites에서 API Routes Response 사용
[API ROUTES](https://nextjs.org/docs/api-routes/response-helpers)
>기존의 ServiceKey를 숨기는 방법으로 rewrites를 시도하였지만 API Routes Response를 통해 수정 

## 1️⃣ env 파일 수정
```js
SERVICE_KEY=serviceKey=.....서비스키 
SERVICE_TYPE=MobileOS=ETC&MobileApp=AppTest&_type=json
```

## 2️⃣ 요청 API의 ServiceKey 숨기기
### 기존의 배포된 API 요청 코드
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/59253551/204710825-1e61e2d7-ec85-47b2-90f8-de5f56d36246.png">

### API Route를 사용한 수정된 API 요청 코드 
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/59253551/204710881-2510fcaa-f8ba-47a7-a9dc-604aa6611cf4.png">

>배포된 상태는 아니지만 중요한 부분은 ServiceKey를 숨기고도 정상적으로 동작하게 만드는 것이다. 

# 🟧 진정한 SSR을 하기 (상세페이지 [id].js)
>기존의 배포된 웹사이트는 Next.js를 활용한 SSR을 사용은 했지만, 정말 효율적인 SSR을 사용하지 못했다. 

## 1️⃣ 기존 배포 네트워크 결과
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/59253551/204725686-28dfb5e2-0d9c-4a53-b5a7-98f249174ff7.png">

>처음 받아오는 내용이 HTML이 있긴하지만 채워진 상태로 받아오는 것이 아니었다. 
다시 getServerSideProps를 통해 axios를 통해 API를 요청한 내용을 받아 useEffect를 처리해 Client에서 업데이트를 했었다. 
(생각해보면 왜 이렇게 했는지 나도 모르겠다.)

```js

const Content = ({
  content: serverSierContent,
  imageLists: serverSideImageLists,
}) => {
  const [content, setContent] = useState([]);
  const [imageLists, setImageLists] = useState([]);

  useEffect(() => {
    setContent(serverSierContent);
    setImageLists(serverSideImageLists);
  }, []);
.....
}

// 여기 데이터로 먼저 API 호출 진행
export async function getServerSideProps({ query }) {
  let content, imageLists;
  async function searchList(pageNo = 1, keyword) {
    const data = await getServerSideSearchList(pageNo, keyword);
    content = data[0];
  }

  async function imageList(pageNo = 1, contentId) {
    const data = await getServerSideImageList(pageNo, contentId);
    imageLists = data;
  }
  await searchList(1, query.keyword);
  await imageList(1, query.id);

  return { props: { content, imageLists } };
}
```

# 🟨 수정한 로컬결과 
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/59253551/204726099-ca0049bc-0de9-4de6-a131-651a11477dfb.png">

>서버에서 받을 때 이미 채워진 상태로 받게 처리했다. 
이로써 Client에서 따로 업데이트 하는 것이 불필요하다. 

```js
const Content = ({ serverImage, serverContent }) => {
  return (
    <>
      <Header />
      <Body id="backgroundLightGray">
        <Main>
          <Title id="titleText">🏕️ {serverContent?.facltNm}</Title>
          {serverImage.length !== 0 && <Slider imgs={serverImage} width={40} />}
          <IntroContainer>
            <Intro introText={serverContent?.intro} />
          </IntroContainer>
          <Location>
            <div id="titleText">위치</div>
            <div id="subText">{serverContent?.addr1}</div>
          </Location>
          <KakaoAPI
            long={serverContent?.mapX}
            lati={serverContent?.mapY}
            marginH={10}
          />
        </Main>
      </Body>
      <Footer />
    </>
  );
};

export async function getServerSideProps(context) {
  const { id, keyword } = context.query;
  const image = await getServerSideImageList(1, id);
  const content = await getServerSideSearchList(1, keyword);
  return {
    props: { serverContent: content[0], serverImage: image },
  };
}
```
# 🟨 메인페이지 리렌더링 문제 해결하기 
## 1️⃣ 기존 메인페이지의 문제점
<img width="534" alt="image" src="https://user-images.githubusercontent.com/59253551/204959964-3ebfbe9b-36ad-4bf9-b74d-510f0ce74718.png">

> GPS를 통한 location 요청과 GPS가 없는 based 요청이 서로 보내지면서 
GPS가 없는 based 요청값이 늦게 받아와진다면 기존의 GPS 데이터가 GPS가 있음에도 나중에 받아진 GPS가 없는 데이터에 의해 렌더링 된 것을 확인할 수 있다. 
이는 GPS가 있는 곳에서 보여지는 제대로 된 GPS 관련 주변 캠핑장 결과를 낼 수 없다.  
(현재 GPS가 있음에도 전남과 강원으로 완전 다른 캠핑장을 보여주고 있다.)

<img width="841" alt="image" src="https://user-images.githubusercontent.com/59253551/204961568-f59057e3-a31c-41b5-b3a7-4f1f63f4bde0.png">
> 대략 이런 상황이다.

## 2️⃣ 코드 수정하기 
시도한 방법은 GPS를 체크한 후에 상태값을 갱신하고 해당 갱신하기전에는 API 호출을 진행하지 않는 것이다. 

```js
  const gpsCheck = useRef(false);
  ...
  useEffect(() => {
    getLocation(setGpsData, gpsCheck);
  }, []);

  useEffect(() => {
    // GPS Data 여부에 따라 API 분기 실행
    if (Object.keys(gpsData).length === 0 && gpsCheck.current) {
      basedList();
    } else if (Object.keys(gpsData).length !== 0 && gpsCheck.current) {
      locationBasedList();
    }
  }, [gpsData]);
```
>`gpsCheck.current`는 GPS여부를 체크 한 후에 false에서 true로 진행된다. 
즉, GPS가 있는지 없는지를 확인하기 전까지는 API 호출을 진행하지 않게 만든다.

## 3️⃣ 수정 메인페이지 결과
<img width="535" alt="image" src="https://user-images.githubusercontent.com/59253551/204960394-92698366-890e-41f3-a9b2-630c0a5ae996.png">

콘솔도 불필요한 부분은 나타나지 않고 이를 통해 API를 불필요하게 요청할 필요가 없어서 좀 더 빠른 UX 경험을 할 수 있다.   
(이제는 용인과 오산인 가까운 캠핑장을 검색해준다.)

<img width="721" alt="image" src="https://user-images.githubusercontent.com/59253551/204961904-2231e6d0-0747-4801-9e56-4dc637e67c33.png">


TODOS
* getServerSide로 쓰는 것은 API가 아직 보이니 해당 부분 수정 
