### PR TITLE
disabled 초기값으로 선택 및 변경시 해당 값으로 처리

### DIFF
--- a/components/SelectBox/SelectBox.tsx
+++ b/components/SelectBox/SelectBox.tsx
@@ -12,8 +12,8 @@ export default function SelectBox({
   changeSelectBoxOption,
 }: SelectBoxProps) {
   return (
-    <select onChange={changeSelectBoxOption} value={optionsTitle}>
-      <option value={optionsTitle} disabled>
+    <select onChange={changeSelectBoxOption}>
+      <option value={optionsTitle} disabled selected>
         {optionsTitle}
       </option>
       {options.map((option) => (


### PR DESCRIPTION
# 🟥 
## 1️⃣ 기존사항
* km 범위가 바뀌어도 바뀐 범위로 동작은 하지만 select box가 고정된 상태로 존재

## 2️⃣ 수정사항
* 선택한 km로 설정되게 select 태그의 value는 고정되지않게 주어진 부분 삭제
* 초기값이 select option의 맨 첫번째 값이 아니기 위해 disabled에 selected 값 추가




