### PR TITLE
SelectBox 컴포넌트 수정 및 시멘틱태그로 수정 

### DIFF
--- a/components/SelectBox/SelectBox.tsx
+++ b/components/SelectBox/SelectBox.tsx
@@ -1,26 +1,20 @@
 import React from "react";
 
 interface SelectBoxProps {
-  optionsTitle: string;
+  defaultValue: string;
+  placeholder: string;
   options: string[];
-  changeSelectBoxOption: (event: React.ChangeEvent) => void;
+  handleChangeOptions: (event: React.ChangeEvent) => void;
 }
 
 export default function SelectBox({
-  optionsTitle = "optionsTitle",
+  defaultValue,
+  placeholder,
   options = [],
-  changeSelectBoxOption,
+  handleChangeOptions,
 }: SelectBoxProps) {
-  return (
-    <select onChange={changeSelectBoxOption} value={optionsTitle}>
-      <option value={optionsTitle} disabled>
-        {optionsTitle}
-      </option>
-      {options.map((option) => (
-        <option value={option} key={option}>
-          {option}
-        </option>
-      ))}
-    </select>
-  );
+  return <select defaultValue={defaultValue ? defaultValue : 'placeholder'} onChange={handleChangeOptions}>
+    {!defaultValue && <option value='placeholder' key={'placeholder'} disabled hidden>{placeholder}</option>}
+    {options.map(option => <option key={option} value={option}>{option}</option>)}
+  </select>
 }

--- a/components/Semantic/Footer/Footer.tsx
+++ b/components/Semantic/Footer/Footer.tsx
@@ -1,37 +1,39 @@
 import React from "react";
 import styled from "styled-components";
 
+const footer_data = {
+  'copyright': 'COPYRIGHT 2022 BY CampInLife ALL RIGHT RESERVED',
+  'information': {
+    'phone': '전화 : 010-3266-1140',
+    'email': '이메일 : khw970421@kakao.com',
+    'github': 'GitHub : khw970421',
+  }
+}
+
 const Footer = () => {
+  const { copyright, information } = footer_data
   return (
     <FooterContainer>
-      <div id="displayMax700">
-        COPYRIGHT 2022 BY CampInLife ALL RIGHT RESERVED
-      </div>
-      <div>
-        <Information>💻 개발자 정보</Information>
-        <Phone>📱 &nbsp;&nbsp;전화 : 010-3266-1140 </Phone>
-        <div>✉️ 이메일 : khw970421@kakao.com</div>
-        <div>📜 GitHub : khw970421</div>
-      </div>
+      <CopyRight>{copyright}</CopyRight>
+      <Information>
+        <h3>💻 개발자 정보</h3>
+        {Object.values(information).map(data => <span key={data}>{data}</span>)}
+      </Information>
     </FooterContainer>
   );
 };
 
-const FooterContainer = styled.div`
+const FooterContainer = styled.footer`
   display: flex;
   justify-content: space-around;
   align-items: center;
   padding: 5px 0px;
 `;
 
-const Information = styled.div`
-  font-weight: bold;
-  font-size: 1em;
-  padding: 10px 0px;
-`;
-
-const Phone = styled.div`
-  white-space: pre;
-`;
+const CopyRight = styled.p``
+const Information = styled.p`
+  display:flex;
+  flex-direction:column;
+`
 
 export default Footer;

--- a/components/Semantic/Header/ts/Header.tsx
+++ b/components/Semantic/Header/ts/Header.tsx
@@ -53,7 +53,7 @@ export default function Header({
   );
 }
 
-const HeaderContainer = styled.div`
+const HeaderContainer = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,13 @@
-import styled from "styled-components";
-import { useEffect, useState, useRef, useCallback } from "react";
+import styled from 'styled-components'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import {
   getBasedList,
   getLocationBasedList,
   getSearchList,
-} from "@/core/api/axios";
-import { useRouter } from "next/router";
+} from '@/core/api/axios'
+import { useRouter } from 'next/router'
 
-import { returnTitle, getLocation } from "@/core/utils/mainPage";
+import { returnTitle, getLocation } from '@/core/utils/mainPage'
 
 import {
   Header,
@@ -15,80 +15,80 @@ import {
   Button,
   SelectBox,
   Footer,
-} from "@/components/index.js";
+} from '@/components/index.js'
 
 export default function Home() {
-  const [titleTag, setTitleTag] = useState("nogps");
-  const [campData, setCampData] = useState([]);
-  const pageNo = useRef(1);
-  const [gpsData, setGpsData] = useState({});
-  const gpsRange = useRef(10000);
-  const gpsCheck = useRef(false);
+  const [titleTag, setTitleTag] = useState('nogps')
+  const [campData, setCampData] = useState([])
+  const pageNo = useRef(1)
+  const [gpsData, setGpsData] = useState({})
+  const gpsRange = useRef(10000)
+  const gpsCheck = useRef(false)
 
-  const [searchArr, setSearchArr] = useState([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const searchKey = useRef("");
+  const [searchArr, setSearchArr] = useState([])
+  const [isSearching, setIsSearching] = useState(false)
+  const searchKey = useRef('')
 
-  const isMounted = useRef(false);
-  const router = useRouter();
+  const isMounted = useRef(false)
+  const router = useRouter()
 
   useEffect(() => {
-    getLocation(setGpsData, gpsCheck);
-  }, []);
+    getLocation(setGpsData, gpsCheck)
+  }, [])
   useEffect(() => {
     // GPS Data 여부에 따라 API 분기 실행
     if (Object.keys(gpsData).length === 0 && gpsCheck.current) {
-      basedList();
+      basedList()
     } else if (Object.keys(gpsData).length !== 0 && gpsCheck.current) {
-      locationBasedList();
+      locationBasedList()
     }
-  }, [gpsData]);
+  }, [gpsData])
 
   // Header 검색 기능
   const changeSearchValue = useCallback(async ({ target }) => {
-    if (target.value !== "") {
-      const list = await getSearchList(1, target.value);
+    if (target.value !== '') {
+      const list = await getSearchList(1, target.value)
       const filterList = list.map(({ facltNm, contentId, mapX, mapY }) => ({
         facltNm,
         contentId,
         mapX,
         mapY,
-      }));
+      }))
 
-      setIsSearching(true);
-      setSearchArr(filterList);
+      setIsSearching(true)
+      setSearchArr(filterList)
     } else {
-      setIsSearching(false);
-      setSearchArr([]);
+      setIsSearching(false)
+      setSearchArr([])
     }
-  }, []);
+  }, [])
 
   const checkSearchPressEnter = useCallback(
     ({ target, key }, idx, facltNm, contentId) => {
       if (idx === -1) {
-        searchList(1, target.value);
-        setSearchArr([]);
-        setIsSearching(false);
+        searchList(1, target.value)
+        setSearchArr([])
+        setIsSearching(false)
       } else {
-        router.push(`/content/${contentId}?keyword=${facltNm}`);
+        router.push(`/content/${contentId}?keyword=${facltNm}`)
       }
     },
     []
-  );
+  )
 
   const clearSearchArr = useCallback(() => {
-    setSearchArr([]);
-    setIsSearching(false);
-  }, []);
+    setSearchArr([])
+    setIsSearching(false)
+  }, [])
 
   // API 기능 : basedList
   async function basedList(pageNo = 1) {
-    const data = await getBasedList(pageNo);
-    setTitleTag("nogps");
+    const data = await getBasedList(pageNo)
+    setTitleTag('nogps')
     // 요청받은 API는 없고 pageNo는 첫번째 페이지가 아닐때
     if (data?.length === 0 && pageNo !== 1) {
-      alert("더보기 캠핑 목록이 없습니다.");
-    } else if (data !== undefined) setCampData([...campData, ...data]);
+      alert('더보기 캠핑 목록이 없습니다.')
+    } else if (data !== undefined) setCampData([...campData, ...data])
   }
 
   // API 기능 : locationBasedList
@@ -97,61 +97,61 @@ export default function Home() {
       mapX: gpsData.long,
       mapY: gpsData.lati,
       radius: gpsRange.current,
-    };
+    }
 
-    const data = await getLocationBasedList(pageNo, gpsInfo);
-    setTitleTag("gps");
+    const data = await getLocationBasedList(pageNo, gpsInfo)
+    setTitleTag('gps')
 
     if (pageNo === 1) {
-      setCampData(data);
+      setCampData(data)
     } else if (data.length === 0 && pageNo !== 1) {
-      alert("더보기 캠핑 목록이 없습니다.");
-    } else setCampData([...campData, ...data]);
+      alert('더보기 캠핑 목록이 없습니다.')
+    } else setCampData([...campData, ...data])
   }
 
   // API 기능 : searchList
   async function searchList(pageNo, value) {
-    const list = await getSearchList(pageNo, value);
-    setTitleTag("searchKey");
+    const list = await getSearchList(pageNo, value)
+    setTitleTag('searchKey')
 
-    searchKey.current = value;
+    searchKey.current = value
     // Todo : 검색이 좀 더 빠를때 searchArr 수정이 안된다. (useEffect로 처리할 필요 있다.)
-    setSearchArr([]);
+    setSearchArr([])
 
     if (pageNo === 1) {
-      setCampData(list);
+      setCampData(list)
     } else if (list.length === 0 && pageNo !== 1) {
-      alert("더보기 캠핑 목록이 없습니다.");
-    } else setCampData([...campData, ...list]);
+      alert('더보기 캠핑 목록이 없습니다.')
+    } else setCampData([...campData, ...list])
   }
 
   // 더보기 기능
   const clickBtn = () => {
-    pageNo.current++;
+    pageNo.current++
 
     switch (titleTag) {
-      case "nogps":
-        basedList(pageNo.current);
-        break;
-      case "gps":
-        locationBasedList(pageNo.current);
-        break;
-      case "searchKey":
-        searchList(pageNo.current, searchKey.current);
-        break;
+      case 'nogps':
+        basedList(pageNo.current)
+        break
+      case 'gps':
+        locationBasedList(pageNo.current)
+        break
+      case 'searchKey':
+        searchList(pageNo.current, searchKey.current)
+        break
       default:
-        alert(`더보기 기능에 문제가 발생했습니다.`);
-        pageNo.current--;
-        break;
+        alert(`더보기 기능에 문제가 발생했습니다.`)
+        pageNo.current--
+        break
     }
-  };
+  }
 
   // GPS 범위 기능
-  const changeSelectBoxOption = ({ target }) => {
-    gpsRange.current = parseInt(target.value) * 1000;
-    pageNo.current = 1;
-    locationBasedList(pageNo.current);
-  };
+  const handleChangeOptions = ({ target }) => {
+    gpsRange.current = parseInt(target.value) * 1000
+    pageNo.current = 1
+    locationBasedList(pageNo.current)
+  }
 
   return (
     <>
@@ -169,22 +169,23 @@ export default function Home() {
             <TitleText width={15} height={30}>
               {returnTitle(titleTag, searchKey.current)}
             </TitleText>
-            {titleTag === "gps" && (
+            {titleTag === 'gps' && (
               <SelectBox
-                optionsTitle={"범위 설정"}
-                options={["1km", "5km", "10km", "20km"]}
-                changeSelectBoxOption={changeSelectBoxOption}
+                placeholder={'범위 설정'}
+                defaultValue={'10km'}
+                options={['1km', '5km', '10km', '20km']}
+                handleChangeOptions={handleChangeOptions}
               />
             )}
           </Title>
           <CampTile campData={campData} isHoverActive={!isSearching} />
           {campData.length !== 0 ? (
             <Button
-              id={"backgroundLightMainColor"}
+              id={'backgroundLightMainColor'}
               width={30}
               height={60}
               marginH={20}
-              btnText={"더보기"}
+              btnText={'더보기'}
               clickBtn={clickBtn}
             ></Button>
           ) : (
@@ -194,18 +195,18 @@ export default function Home() {
       </Body>
       <Footer />
     </>
-  );
+  )
 }
 
 const TitleText = styled.div`
   margin: 20px;
   min-width: 150px;
-`;
+`
 
 const Body = styled.div`
   width: 100%;
   min-height: 100vh;
-`;
+`
 
 const Main = styled.div`
   display: flex;
@@ -218,11 +219,11 @@ const Main = styled.div`
     width: calc(100vw - 5vw * 2);
     margin: 5vw;
   }
-`;
+`
 
 const Title = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-`;
+`

--- a/pages/index.js
+++ b/pages/index.js
@@ -203,7 +203,7 @@ const TitleText = styled.div`
   min-width: 150px;
 `
 
-const Body = styled.div`
+const Body = styled.main`
   width: 100%;
   min-height: 100vh;
 `


### PR DESCRIPTION
## 1️⃣ SelectBox 컴포넌트 수정 
### 기존 문제점 
* 사용자 입장에서 10km로 캠핑장 검색 범위가 설정되어있음에도 '초기설정'이라고 기본 SelectBox가 나타난다. 

### 수정 사항
* defaultValue라는 props의 유무에 따라 주어진 defaultValue로 처리할지 placeholder('초기설정')으로 나타날지를 처리하게 수정

```js
<select defaultValue={defaultValue ? defaultValue : 'placeholder'} onChange={handleChangeOptions}>
    {!defaultValue && <option value='placeholder' key={'placeholder'} disabled hidden>{placeholder}</option>}
    {options.map(option => <option key={option} value={option}>{option}</option>)}
  </select>
``` 

## 2️⃣ Footer의 footer_data를 분리 - 이후 footer_data가 수정되어도 대처하기 쉽게 처리 
(기존의 형태로는 return 태그의 ui에 직접 코드를 수정을 해야함)

## 3️⃣ 시멘틱태그로 검색엔진 최적화처리 


