### PR TITLE
⭐ Main Page 리팩토링 - GPS State, if deps 감소

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -4,18 +4,17 @@ import styled from "styled-components";
 interface BtnStyled {
   width: number;
   height: number;
-  borderRadius: number;
-  fSize: number;
-  marginH: number;
-  marginV: number;
-  paddingH: number;
-  paddingV: number;
+  borderRadius?: number;
+  fSize?: number;
+  marginH?: number;
+  marginV?: number;
+  paddingH?: number;
+  paddingV?: number;
 }
-
 interface BtnProps extends BtnStyled {
   id: string;
   clickBtn: () => void;
-  btnText: string;
+  btnText: string
 }
 
 export default function Button({

--- a/components/CampingBoxGroup/CampingBoxGroup.tsx
+++ b/components/CampingBoxGroup/CampingBoxGroup.tsx
@@ -88,14 +88,14 @@ interface CampDataObj {
 }
 
 interface ContainerStyled {
-  containerWidth: number;
+  containerWidth?: number;
 }
 
 interface CampingBoxGroupProps extends ContainerStyled {
   campData: CampDataObj[];
   isHoverActive: boolean;
-  containerWidth: number;
-  containerHeight: number;
+  containerWidth?: number;
+  containerHeight?: number;
 }
 
 export default function CampingBoxGroup({

--- a/components/Semantic/Header/Header.tsx
+++ b/components/Semantic/Header/Header.tsx
@@ -21,7 +21,7 @@ interface HeaderProps {
     facltNm?: string,
     contentId?: string
   ) => void;
-  clearSearchArr: () => void;
+  handleClearSearchData: () => void;
 }
 
 export default function Header({
@@ -29,7 +29,7 @@ export default function Header({
   searchArr = [],
   changeInputValue,
   checkSearchPressEnter,
-  clearSearchArr,
+  handleClearSearchData,
   isSearching,
 }: HeaderProps) {
   const router = useRouter();
@@ -47,7 +47,7 @@ export default function Header({
           isSearching={isSearching}
           changeInputValue={changeInputValue}
           checkSearchPressEnter={checkSearchPressEnter}
-          clearSearchArr={clearSearchArr}
+          handleClearSearchData={handleClearSearchData}
         ></Input>
       )}
       <HamburgerContainer>

--- a/components/Semantic/Header/Input.tsx
+++ b/components/Semantic/Header/Input.tsx
@@ -33,7 +33,7 @@ interface InputProps {
     facltNm?: string,
     contentId?: string
   ) => void;
-  clearSearchArr: () => void;
+  handleClearSearchData: () => void;
   width?: number;
   height?: number;
   borderRadius?: number;
@@ -49,7 +49,7 @@ export default memo(function Input({
   isSearching,
   changeInputValue,
   checkSearchPressEnter,
-  clearSearchArr,
+  handleClearSearchData,
   width = 20,
   height = 50,
   borderRadius = 20,
@@ -60,7 +60,7 @@ export default memo(function Input({
   const router = useRouter();
   const inputRef = useRef();
   const [idx, setIdx] = useState(-1);
-  const debounce = (e) => {
+  const handleDebounce = (e) => {
     if (timer) {
       clearTimeout(timer); // 0.5초 미만으로 입력이 주어질 경우 해당 timer를 clear(없앤다)한다.
     }
@@ -68,26 +68,20 @@ export default memo(function Input({
       changeInputValue(e);
     }, 500);
   };
-  function keyUp(e) {
-    if (searchArr.length !== 0) {
-      if (e.key === "ArrowDown") {
-        const nIdx = (idx + 1) % searchArr.length;
-        setIdx(nIdx);
-      } else if (e.key === "ArrowUp") {
-        const nIdx = (idx - 1) % searchArr.length;
-        setIdx(nIdx < 0 ? nIdx + searchArr.length : nIdx);
-      } else if (e.key === "Enter") {
-        if (idx === -1) {
-          checkSearchPressEnter(e, idx);
-        } else {
-          checkSearchPressEnter(
-            e,
-            idx,
-            searchArr[idx].facltNm,
-            searchArr[idx].contentId
-          );
-        }
-      }
+  function handleCheckKeyUp(e) {
+    if (e.key === "ArrowDown" && searchArr.length !== 0) {
+      const nIdx = (idx + 1) % searchArr.length;
+      setIdx(nIdx);
+    } else if (e.key === "ArrowUp" && searchArr.length !== 0) {
+      const nIdx = (idx - 1) % searchArr.length;
+      setIdx(nIdx < 0 ? nIdx + searchArr.length : nIdx);
+    } else if (e.key === "Enter") {
+      checkSearchPressEnter(
+        e,
+        idx,
+        searchArr[idx]?.facltNm,
+        searchArr[idx]?.contentId
+      );
     }
   }
 
@@ -113,11 +107,11 @@ export default memo(function Input({
         <InputTag
           id={id}
           ref={inputRef}
-          onChange={debounce}
-          onBlur={clearSearchArr}
+          onChange={handleDebounce}
+          onBlur={handleClearSearchData}
           width={width}
           height={height}
-          onKeyUp={keyUp}
+          onKeyUp={handleCheckKeyUp}
         ></InputTag>
         <LeftPadding borderRadius={borderRadius}></LeftPadding>
       </InputTagContainer>

--- a/core/utils/mainPage.js
+++ b/core/utils/mainPage.js
@@ -1,36 +1,42 @@
-const returnTitle = (titleTag, searchKey = "") => {
+const returnTitle = (titleTag, searchKey = '') => {
   const titleCase = {
-    gps: "주변 캠핑장 목록",
-    nogps: "캠핑장 목록",
+    gps: '주변 캠핑장 목록',
+    nogps: '캠핑장 목록',
     searchKey: `검색 결과 : ${searchKey}`,
-  };
-  return "🏕️ " + titleCase[titleTag];
-};
+  }
+  return '🏕️ ' + titleCase[titleTag]
+}
 
-function getLocation(setData, gpsCheck) {
+function getLocation(setData) {
   if (navigator.geolocation) {
     // GPS를 지원하면
     navigator.geolocation.getCurrentPosition(
+      // GPS 허용
       function (position) {
-        setData({
+        setData((data) => ({
+          ...data,
           lati: position.coords.latitude,
           long: position.coords.longitude,
-        });
-        gpsCheck.current = true;
+          isGpsCheck: true,
+        }))
       },
+      // GPS 차단
       function (error) {
-        gpsCheck.current = true;
-        console.error(error);
+        setData((data) => ({
+          ...data,
+          isGpsCheck: true,
+        }))
+        console.error(error)
       },
       {
         enableHighAccuracy: false,
         maximumAge: 0,
         timeout: Infinity,
       }
-    );
+    )
   } else {
-    alert("GPS를 지원하지 않습니다");
+    alert('GPS를 지원하지 않습니다')
   }
 }
 
-export { returnTitle, getLocation };
+export { returnTitle, getLocation }

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,26 +21,21 @@ export default function Home() {
   const [titleTag, setTitleTag] = useState('nogps')
   const [campData, setCampData] = useState([])
   const pageNo = useRef(1)
-  const [gpsData, setGpsData] = useState({})
-  const gpsRange = useRef(10000)
-  const gpsCheck = useRef(false)
+  const [gpsData, setGpsData] = useState({ gpsRange: 10000, isGpsCheck: false })
 
   const [searchArr, setSearchArr] = useState([])
   const [isSearching, setIsSearching] = useState(false)
   const searchKey = useRef('')
 
-  const isMounted = useRef(false)
   const router = useRouter()
 
   useEffect(() => {
-    getLocation(setGpsData, gpsCheck)
+    getLocation(setGpsData)
   }, [])
+
   useEffect(() => {
-    // GPS Data 여부에 따라 API 분기 실행
-    if (Object.keys(gpsData).length === 0 && gpsCheck.current) {
-      basedList()
-    } else if (Object.keys(gpsData).length !== 0 && gpsCheck.current) {
-      locationBasedList()
+    if (gpsData.isGpsCheck) {
+      gpsData.lati && gpsData.long ? locationBasedList() : basedList()
     }
   }, [gpsData])
 
@@ -96,7 +91,7 @@ export default function Home() {
     const gpsInfo = {
       mapX: gpsData.long,
       mapY: gpsData.lati,
-      radius: gpsRange.current,
+      radius: gpsData.gpsRange,
     }
 
     const data = await getLocationBasedList(pageNo, gpsInfo)
@@ -148,7 +143,8 @@ export default function Home() {
 
   // GPS 범위 기능
   const handleChangeOptions = ({ target }) => {
-    gpsRange.current = parseInt(target.value) * 1000
+    const newGpsRange = parseInt(target.value) * 1000
+    setGpsData((data) => ({ ...data, gpsRange: newGpsRange }))
     pageNo.current = 1
     locationBasedList(pageNo.current)
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,7 +78,7 @@ export default function Home() {
     []
   )
 
-  const clearSearchArr = useCallback(() => {
+  const handleClearSearchData = useCallback(() => {
     setSearchArr([])
     setIsSearching(false)
   }, [])
@@ -163,7 +163,7 @@ export default function Home() {
         searchArr={searchArr}
         changeInputValue={changeSearchValue}
         checkSearchPressEnter={checkSearchPressEnter}
-        clearSearchArr={clearSearchArr}
+        handleClearSearchData={handleClearSearchData}
         isSearching={isSearching}
       />
       <Body id="backgroundLightGray">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,13 +15,20 @@ import {
   Button,
   SelectBox,
   Footer,
-} from '@/components/index.ts'
+} from '@/components/index'
+
+interface GpsData {
+  gpsRange: number
+  isGpsCheck: boolean
+  lati?: number
+  long?: number
+}
 
 export default function Home() {
   const [titleTag, setTitleTag] = useState('nogps')
   const [campData, setCampData] = useState([])
   const pageNo = useRef(1)
-  const [gpsData, setGpsData] = useState({ gpsRange: 10000, isGpsCheck: false })
+  const [gpsData, setGpsData] = useState<GpsData>({ gpsRange: 10000, isGpsCheck: false })
 
   const [searchArr, setSearchArr] = useState([])
   const [isSearching, setIsSearching] = useState(false)
@@ -59,7 +66,7 @@ export default function Home() {
   }, [])
 
   const checkSearchPressEnter = useCallback(
-    ({ target, key }, idx, facltNm, contentId) => {
+    ({ target }, idx, facltNm, contentId) => {
       if (idx === -1) {
         searchList(1, target.value)
         setSearchArr([])
@@ -162,7 +169,7 @@ export default function Home() {
       <Body id="backgroundLightGray">
         <Main>
           <Title>
-            <TitleText width={15} height={30}>
+            <TitleText>
               {returnTitle(titleTag, searchKey.current)}
             </TitleText>
             {titleTag === 'gps' && (


### PR DESCRIPTION
## 1️⃣ GPS 상태값에 Range, Check 포함하여 수정
### 기존 상태
useRef를 통해 `gpsRange`와 `gpsCheck` 그리고 useState를 사용한 `gpsData`가 각각 분리된 상태

### 수정 이유
gps와 관련 부분들이 불필요하게 분리될 필요성이 없고, 함께 사용할 경우 특정 부분에서도 가독성이 좋아진다. 

 ```js
    const gpsInfo = {
      mapX: gpsData.long,
      mapY: gpsData.lati,
      radius: gpsData.gpsRange  
    }
```
* 기존에 `radius : gpsRange.current` 이었던 부분을 `gpsData`로 시작하는 value 값으로 통일 

### 수정 gpsData
```js
interface GpsData {
  gpsRange: number
  isGpsCheck: boolean
  lati?: number
  long?: number
}
```

## 2️⃣  메인페이지 index.js -> index.tsx 수정
* 관련된 styled-components typescript 관련 오류 수정 

## 3️⃣ handleCheckKeyUp if문 최대 3deps 수정
### 기존 코드 
```js
function keyUp(e) {
    if (searchArr.length !== 0) {
      if (e.key === "ArrowDown") {
        ...
      } else if (e.key === "ArrowUp") {
        ...
      } else if (e.key === "Enter") {
        if (idx === -1) {
          ...
        } else {
          ...
        }
      }
}
```
* if문을 2번 반복하는 3개의 deps 존재

### 수정 코드
```js
function handleCheckKeyUp(e) {
    // 검색 결과 존재 O , ArrowDown keyPress
    if (e.key === "ArrowDown" && searchArr.length !== 0) {
      const nIdx = (idx + 1) % searchArr.length;
      setIdx(nIdx);
    } 
   // 검색 결과 존재 O , ArrowUp keyPress
   else if (e.key === "ArrowUp" && searchArr.length !== 0) {
      const nIdx = (idx - 1) % searchArr.length;
      setIdx(nIdx < 0 ? nIdx + searchArr.length : nIdx);
    }
   // 검색 결과와 관계 없이 검색한 내용에 대한 처리 진행 
   else if (e.key === "Enter") {
      // idx가 -1일 경우 해당 페이지에서 관련 캠핑장 검색 
     // 아닐경우 관련 검색 내용의 해당 캠핑장의 상세페이지로 라우팅 처리  
      checkSearchPressEnter(
        e,
        idx,
        searchArr[idx]?.facltNm,
        searchArr[idx]?.contentId
      );
    }
}
```
* 불필요한 if문의 deps를 1개로 수정, 기존의 keyUp이라는 이름에 대해 handleCheckKeyUp으로 구체적인 함수명으로 수정 
