### PR TITLE
Refactor main page - types.d.ts, useCallback

### DIFF
--- a/components/CampingBoxGroup/CampingBoxGroup.tsx
+++ b/components/CampingBoxGroup/CampingBoxGroup.tsx
@@ -9,14 +9,14 @@ interface ContainerStyled {
 }
 
 interface CampingBoxGroupProps extends ContainerStyled {
-  CampingInfo: CampingInfo[];
+  campingInfo: CampingInfo[];
   isHoverActive: boolean;
   containerWidth?: number;
   containerHeight?: number;
 }
 
 export default function CampingBoxGroup({
-  CampingInfo = [],
+  campingInfo = [],
   isHoverActive = true,
   containerWidth = 223,
   containerHeight = 300,
@@ -24,7 +24,7 @@ export default function CampingBoxGroup({
   const returnImageSrc = (url) => (url !== "" ? url : logo);
   return (
     <Container containerWidth={containerWidth}>
-      {CampingInfo.map(({ facltNm, addr1, firstImageUrl, contentId }) => (
+      {campingInfo.map(({ facltNm, addr1, firstImageUrl, contentId }) => (
         <CampingBox
           key={contentId}
           title={facltNm}

--- a/components/CampingBoxGroup/CampingBoxGroup.tsx
+++ b/components/CampingBoxGroup/CampingBoxGroup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import CampingBox from "./CampingBox";
 import logo from "@/public/logo.png";
-import { CampingInfo } from "@/core/utils/types";
+import { CampingInfo } from "@/core/utils/types.d";
 
 interface ContainerStyled {
   containerWidth?: number;

--- a/components/Semantic/Header/Header.tsx
+++ b/components/Semantic/Header/Header.tsx
@@ -4,7 +4,7 @@ import { GiHamburgerMenu } from "react-icons/gi";
 import Input from "@/components/Semantic/Header/Input";
 import { useRouter } from "next/router";
 import Image from "next/image";
-import { SearchCamping } from "@/core/utils/types";
+import { SearchCamping } from "@/core/utils/types.d";
 
 
 interface HeaderProps {

--- a/components/Semantic/Header/Input.tsx
+++ b/components/Semantic/Header/Input.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState, memo } from "react";
 import { useRouter } from "next/router";
 import styled from "styled-components";
 import { ImSearch } from "react-icons/im";
-import { SearchCamping } from "@/core/utils/types";
+import { SearchCamping } from "@/core/utils/types.d";
 
 interface UlStyled {
   width: number;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
   const changeSearchValue = useCallback(async ({ target }) => {
     if (target.value !== '') {
       pageNo.current = 1
-      const list = await getSearchList(target.value)
+      const list = await getSearchList(pageNo.current, target.value)
       const filterList = list.map(({ facltNm, contentId, mapX, mapY }) => ({
         facltNm,
         contentId,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import {
   getSearchList,
 } from '@/core/api/axios'
 import { returnTitle, getLocation } from '@/core/utils/mainPage'
-import { TitleTag, CampingInfo, GpsData, SearchCamping } from '@/core/utils/types'
+import { TitleTag, CampingInfo, GpsData, SearchCamping } from '@/core/utils/types.d'
 import {
   Header,
   CampingBoxGroup,
@@ -121,7 +121,7 @@ export default function Home() {
   }
 
   // 더보기 기능
-  const clickBtn = () => {
+  const addCampingInfo = () => {
     pageNo.current++
 
     switch (titleTag) {
@@ -182,7 +182,7 @@ export default function Home() {
               height={60}
               marginH={20}
               btnText={'더보기'}
-              clickBtn={clickBtn}
+              clickBtn={addCampingInfo}
             ></Button>
           ) : (
             <div> 검색 결과가 없습니다. </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,23 +29,25 @@ export default function Home() {
 
   const router = useRouter()
 
-  const updateCampingInfo = (campingInfo: CampingInfo[], newCampingInfo: CampingInfo[], pageNo: number) => {
+  const updateCampingInfo = useCallback((newCampingInfo: CampingInfo[], pageNo: number) => {
     if (!newCampingInfo) {
       alert('더보기 캠핑 목록이 없습니다.')
       return
     }
 
-    const updatedCampingInfo = pageNo === 1 ? newCampingInfo : [...campingInfo, ...newCampingInfo]
-    setCampingInfo(updatedCampingInfo)
-  }
+    setCampingInfo((campingInfo) => {
+      const updatedCampingInfo = pageNo === 1 ? newCampingInfo : [...campingInfo, ...newCampingInfo]
+      return updatedCampingInfo
+    })
+  }, [])
 
   // API 기능 : basedList
   const basedList = useCallback(async () => {
     const newCampingInfo = await getBasedList(pageNo.current)
     setTitleTag('nogps')
 
-    updateCampingInfo(campingInfo, newCampingInfo, pageNo.current)
-  }, [campingInfo])
+    updateCampingInfo(newCampingInfo, pageNo.current)
+  }, [updateCampingInfo])
 
   // API 기능 : locationBasedList
   const locationBasedList = useCallback(async (gpsData) => {
@@ -58,8 +60,8 @@ export default function Home() {
     const newCampingInfo = await getLocationBasedList(pageNo.current, gpsInfo)
     setTitleTag('gps')
 
-    updateCampingInfo(campingInfo, newCampingInfo, pageNo.current)
-  }, [campingInfo])
+    updateCampingInfo(newCampingInfo, pageNo.current)
+  }, [updateCampingInfo])
 
   // API 기능 : searchList
   const searchList = useCallback(async (value) => {
@@ -69,13 +71,12 @@ export default function Home() {
     searchKey.current = value
     setSearchCamping([])
 
-    updateCampingInfo(campingInfo, newCampingInfo, pageNo.current)
-  }, [campingInfo])
+    updateCampingInfo(newCampingInfo, pageNo.current)
+  }, [updateCampingInfo])
 
   useEffect(() => {
     getLocation(setGpsData)
   }, [])
-
   useEffect(() => {
     if (gpsData.isGpsCheck) {
       gpsData.lati && gpsData.long ? locationBasedList(gpsData) : basedList()


### PR DESCRIPTION
## 1️⃣ types.d.ts로 중복된 타입정의 분리

## 2️⃣ useCallback 매개변수 수정 및 각각의 API 요청 함수들의 중복된 코드 제거 
### 기존 문제점
```js
const updateCampingInfo = useCallback((campingInfo: CampingInfo[], newCampingInfo: CampingInfo[], pageNo: number) => {
if (!newCampingInfo) {
alert('더보기 캠핑 목록이 없습니다.')
return
}

const updatedCampingInfo = pageNo === 1 ? newCampingInfo : [...campingInfo, ...newCampingInfo]
setCampingInfo(updatedCampingInfo)
}, [])

...

useEffect(() => {
  if (gpsData.isGpsCheck) {
    gpsData.lati && gpsData.long ? locationBasedList(gpsData) : basedList()
  }
}, [gpsData, locationBasedList, basedList])

...

const basedList = useCallback(async () => {
  const newCampingInfo = await getBasedList(pageNo.current)
  setTitleTag('nogps')

  updateCampingInfo(campingInfo, newCampingInfo, pageNo.current)
}, [campingInfo, updateCampingInfo])

const locationBasedList = useCallback(async (gpsData) => {
  const gpsInfo = {
    mapX: gpsData.long,
    mapY: gpsData.lati,
    radius: gpsData.gpsRange,
  }

  const newCampingInfo = await getLocationBasedList(pageNo.current, gpsInfo)
  setTitleTag('gps')

  updateCampingInfo(campingInfo, newCampingInfo, pageNo.current)
}, [campingInfo, updateCampingInfo])
```
* 즉, useEffect -> locationBasedList or basedList 함수 실행 -> updateCampingInfo 함수 실행 -> campingInfo 상태값 변경  
-> 다시 관련이 있는 basedList, updateCampingInfo가 새롭게 정의 -> 이에 매개변수로 연관이 있는 useEffect도 변경을 파악하여 또 새롭게 요청 시도 

**한마디로 useCallback으로 묶으려다 불필요한 API를 계속해서 실행하고 불필요한 함수를 중복해서 실행하는 문제 발생**
### 문제 해결 
* campingInfo를 매개변수로 추가하지 않고 setState에서 callback으로 해당 값을 가져와 수행 