### PR TITLE
GPS 주변 범위 수정시 CampingInfo 오류 수정 

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,8 +29,9 @@ export default function Home() {
 
   const router = useRouter()
 
+  // updateCampingInfo, basedList, locationBasedList는 직접 실행 X -> useEffect에 의해 실행 
   const updateCampingInfo = useCallback((newCampingInfo: CampingInfo[], pageNo: number) => {
-    if (!newCampingInfo) {
+    if (!newCampingInfo.length && pageNo !== 1) {
       alert('더보기 캠핑 목록이 없습니다.')
       return
     }
@@ -59,7 +60,6 @@ export default function Home() {
 
     const newCampingInfo = await getLocationBasedList(pageNo.current, gpsInfo)
     setTitleTag('gps')
-
     updateCampingInfo(newCampingInfo, pageNo.current)
   }, [updateCampingInfo])
 
@@ -147,7 +147,6 @@ export default function Home() {
     const newGpsRange = parseInt(target.value) * 1000
     setGpsData((data) => ({ ...data, gpsRange: newGpsRange }))
     pageNo.current = 1
-    locationBasedList(gpsData)
   }
 
   return (

--- a/styles/global.css
+++ b/styles/global.css
@@ -11,6 +11,11 @@ a {
   text-decoration: none;
 }
 
+button{
+  border: 0;
+  background-color: transparent;
+}
+
 /* * {
   box-sizing: border-box;
 } */
@@ -43,19 +48,19 @@ a {
   color: #d9d9d9;
 }
 
-.light-gray {
+.light_gray {
   color: #f7f6fb;
 }
 
-.background-light-main-color {
+.background_light_main_color {
   background-color: #8bc53f50;
 }
 
-.background-white {
+.background_white {
   background-color: #ffffff;
 }
 
-.background-light-gray {
+.background_light_gray {
   background-color: #f7f6fb;
 }
 
@@ -64,12 +69,12 @@ a {
   padding: 0 20%;
 }
 
-.title-text {
+.title_text {
   font-weight: bold;
   font-size: 1rem;
 }
 
-.sub-text {
+.sub_text {
   font-weight: bold;
   font-size: 0.8rem;
 }


### PR DESCRIPTION
## 1️⃣ GPS 주변 범위 수정시 CampingInfo 오류 수정 
### 기존 오류
<img width="536" alt="수정실패" src="https://github.com/khw970421/CampingInLife/assets/59253551/285a1c5a-d6cf-4394-b90a-9428fd0b8965">

* 주변 캠핑장 범위를 수정했을 때 바뀐 후 다시 원래 캠핑장 수 만큼 돌아오는 문제 발생

### 문제 원인
```js
const handleChangeOptions = ({ target }) => {
    const newGpsRange = parseInt(target.value) * 1000
    setGpsData((data) => ({ ...data, gpsRange: newGpsRange }))
    pageNo.current = 1
    locationBasedList(gpsData) // 원인
  }

  useEffect(() => {
    if (gpsData.isGpsCheck) {
      gpsData.lati && gpsData.long ? locationBasedList(gpsData) : basedList()
    }
  }, [gpsData, locationBasedList, basedList])
```
* GPS 변화로 useEffect가 실행되면서 의도한 locationBasedList가 실행되는것과 추가로 handleChangeOptions에서도 현재 GPS(변화하지않은)를 기준으로 locationBasedList가 또다시 실행되는 원인 발생하여 해당 부분을 삭제 

## 2️⃣ ClassName snake_case 수정


