### PR TITLE
검색 후 검색 결과가 남아있는 문제 해결

### DIFF
--- a/components/Semantic/Header/Header.tsx
+++ b/components/Semantic/Header/Header.tsx
@@ -15,8 +15,8 @@ interface HeaderProps {
   checkSearchPressEnter: (
     event: React.MouseEvent,
     idx: number,
-    facltNm?: string,
-    contentId?: string
+    facltNm: string | null,
+    contentId: string | null
   ) => void;
   handleClearSearchData: () => void;
 }

--- a/components/Semantic/Header/Input.tsx
+++ b/components/Semantic/Header/Input.tsx
@@ -58,6 +58,7 @@ export default memo(function Input({
       const facltNm = searchCamping ? searchCamping[idx]?.facltNm : null;
       const contentId = searchCamping ? searchCamping[idx]?.contentId : null;
 
+      clearTimeout(timer)
       checkSearchPressEnter(
         e,
         idx,

--- a/components/Semantic/Header/Input.tsx
+++ b/components/Semantic/Header/Input.tsx
@@ -17,8 +17,8 @@ interface InputProps {
   checkSearchPressEnter: (
     event: React.MouseEvent,
     idx: number,
-    facltNm?: string,
-    contentId?: string
+    facltNm: string | null,
+    contentId: string | null
   ) => void;
   handleClearSearchData: () => void;
   closeSearchBar: () => void;
@@ -55,11 +55,14 @@ export default memo(function Input({
       const nIdx = (idx - 1) % searchCamping.length;
       setIdx(nIdx < 0 ? nIdx + searchCamping.length : nIdx);
     } else if (e.key === "Enter") {
+      const facltNm = searchCamping ? searchCamping[idx]?.facltNm : null;
+      const contentId = searchCamping ? searchCamping[idx]?.contentId : null;
+
       checkSearchPressEnter(
         e,
         idx,
-        searchCamping[idx]?.facltNm,
-        searchCamping[idx]?.contentId
+        facltNm,
+        contentId
       );
       closeSearchBar()
     }


### PR DESCRIPTION
## 1️⃣ 검색 문제 해결

### 원인
1. 검색
2. Enter 클릭
3. checkSearchPressEnter 함수 실행 (`setSearchingCamping([])`)
4. 디바운싱에 의해 그 후 changeInputValue 함수 실행 (`setSearchingCamping(filterList)`)
5. 이로인해 다시 검색창을 확인하면 삭제되지않고 남아있다.

### 해결 
checkSearchPressEnter 함수 실행시 현재 디바운싱 timer를 cleartTimeout 처리

